### PR TITLE
Fix the exception that is thrown when the application is started in iOS simulator or device.

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -1,18 +1,20 @@
 ﻿import application = require("application");
 
-application.onLaunch = function (intent) {
-    console.log("onLaunch");
-    application.android.onActivityCreated = function (activity) {
-        console.log("onCreated");
-        var id = activity.getResources().getIdentifier("AppTheme", "style", activity.getPackageName());
-        activity.setTheme(id);
-    }
+if(application.android) {
+    application.onLaunch = function (intent) {
+        console.log("onLaunch");
+        application.android.onActivityCreated = function (activity) {
+            console.log("onCreated");
+            var id = activity.getResources().getIdentifier("AppTheme", "style", activity.getPackageName());
+            activity.setTheme(id);
+        }
 
-    application.android.onActivityStarted = function (activity) {
-        console.log("onStarted");
-        var window = activity.getWindow();
-        if (window) {
-            window.setBackgroundDrawable(null);
+        application.android.onActivityStarted = function (activity) {
+            console.log("onStarted");
+            var window = activity.getWindow();
+            if (window) {
+                window.setBackgroundDrawable(null);
+            }
         }
     }
 }


### PR DESCRIPTION
An exception is thrown then the application is started in iOS simulator or device. In this case `application.android` is `undefined` and we shouldn't listen to `onActivityCreated` and `onActivityStarted` events.