### PR TITLE
Edit options' platform requirements

### DIFF
--- a/options/package.json
+++ b/options/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "nativescript": {
     "platforms": {
-      "ios": "1.5.0"
+      "ios": "1.3.0"
     }
   }
 }


### PR DESCRIPTION
Merging configuration files from plugins was introduced in {N} Version 1.3.0, so there's no point in requiring 1.5.0 for this plugin
Ping @valentinstoychev @rosen-vladimirov for a quick review